### PR TITLE
bugfix: fix regexp match for comment lines in hosts file

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func hosts() []string {
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			s := scanner.Text()
-			match, _ := regexp.MatchString("^ *(#) *$", s)
+			match, _ := regexp.MatchString("^ *(#).*$", s)
 			fields := strings.Fields(s)
 			if !match && len(fields) >= 2 {
 				hostname := fields[0]


### PR DESCRIPTION
This makes the hosts() function skip all comment lines.